### PR TITLE
Improve Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
 RUN apt-get update
 RUN apt-get install --yes curl gpg git apt-utils default-jdk maven
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/snowblossom-bazel.list
-RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+RUN curl -Ls https://bazel.build/bazel-release.pub.gpg | apt-key add -
 
 RUN apt-get update
 RUN apt-get install --yes bazel

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install --yes curl gpg git apt-utils default-jdk maven
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/snowblossom-bazel.list

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,9 +29,16 @@ RUN chown -R snowblossom:snowblossom /home/snowblossom
 
 USER snowblossom
 WORKDIR /home/snowblossom
-RUN git clone https://github.com/snowblossomcoin/rosesnow.git -b v0.1 rosesnow.git
+RUN mkdir /home/snowblossom/rosesnow
 
 WORKDIR /home/snowblossom/rosesnow
+ARG REFSPEC=v0.1
+RUN git init . \
+  && git remote add origin https://github.com/snowblossomcoin/rosesnow.git \
+  && git fetch origin ${REFSPEC} \
+  && git checkout FETCH_HEAD \
+  && rm -rf .git/
+
 RUN bazel build :RoseSnow_deploy.jar
 
 WORKDIR /home/snowblossom/rosesnow/maven
@@ -43,4 +50,3 @@ RUN mvn package
 CMD mvn jetty:run
 # Run with:
 #  docker run -p 8080:8080/tcp
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
+
 RUN apt-get update -qq \
   && apt-get install -qq --no-install-recommends --no-install-suggests \
     apt-utils \
@@ -9,6 +10,9 @@ RUN apt-get update -qq \
     gpg-agent \
     ca-certificates \
     curl
+
+RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" \
+  > /etc/apt/sources.list.d/snowblossom-bazel.list
 RUN curl -Ls https://bazel.build/bazel-release.pub.gpg | apt-key add -
 
 RUN apt-get update -qq \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 as build
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
@@ -42,11 +42,31 @@ RUN git init . \
 RUN bazel build :RoseSnow_deploy.jar
 
 WORKDIR /home/snowblossom/rosesnow/maven
-
-EXPOSE 8080/tcp
-
 RUN mvn package
 
-CMD mvn jetty:run
-# Run with:
-#  docker run -p 8080:8080/tcp
+FROM ubuntu:20.04 as runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq \
+  && apt-get install -qq --no-install-recommends --no-install-suggests \
+    jetty9 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN rm -rf /var/lib/jetty9/webapps/root/
+COPY --from=build /home/snowblossom/rosesnow/maven/target/snowrosetta-rosesnow.war \
+  /var/lib/jetty9/webapps/ROOT.war
+
+RUN chown -R jetty:adm /var/lib/jetty9/
+USER jetty
+
+ENV JETTY_HOME=/usr/share/jetty9/
+ENV JETTY_STATE=/var/lib/jetty9/jetty.state
+ENV JAVA_OPTS=-Djava.awt.headless=true
+
+CMD /usr/share/jetty9/bin/jetty.sh run
+
+# To build and run any branch or tag:
+# docker build --build-arg REFSPEC=main -t rosesnow-rosetta .
+# docker run -it --rm -p 8080:8080/tcp rosesnow-rosetta

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,15 +3,16 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
 RUN apt-get update -qq \
-  && apt-get install -qq \
+  && apt-get install -qq --no-install-recommends --no-install-suggests \
     apt-utils \
     gpg \
+    gpg-agent \
+    ca-certificates \
     curl
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/snowblossom-bazel.list
 RUN curl -Ls https://bazel.build/bazel-release.pub.gpg | apt-key add -
 
 RUN apt-get update -qq \
-  && apt-get install -qq \
+  && apt-get install -qq --no-install-recommends --no-install-suggests \
     git \
     default-jdk \
     bazel \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,19 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
 RUN apt-get update -qq
-RUN apt-get install -qq apt-utils gpg curl
+RUN apt-get install -qq \
+  apt-utils \
+  gpg \
+  curl
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/snowblossom-bazel.list
 RUN curl -Ls https://bazel.build/bazel-release.pub.gpg | apt-key add -
 
 RUN apt-get update -qq
-RUN apt-get install -qq git default-jdk bazel maven
+RUN apt-get install -qq \
+  git \
+  default-jdk \
+  bazel \
+  maven
 
 RUN mkdir -p /var/build/snow
 WORKDIR /var/build/snowblossom

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get update -qq \
     git \
     default-jdk-headless \
     bazel \
-    maven
+    maven \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/build/snow
 WORKDIR /var/build/snowblossom

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,12 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
 RUN apt-get update -qq
-RUN apt-get install -qq curl gpg git apt-utils default-jdk maven
+RUN apt-get install -qq apt-utils gpg curl
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/snowblossom-bazel.list
 RUN curl -Ls https://bazel.build/bazel-release.pub.gpg | apt-key add -
 
 RUN apt-get update -qq
-RUN apt-get install -qq bazel
+RUN apt-get install -qq git default-jdk bazel maven
 
 RUN mkdir -p /var/build/snow
 WORKDIR /var/build/snowblossom

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,20 +2,20 @@ FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
-RUN apt-get update -qq
-RUN apt-get install -qq \
-  apt-utils \
-  gpg \
-  curl
+RUN apt-get update -qq \
+  && apt-get install -qq \
+    apt-utils \
+    gpg \
+    curl
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/snowblossom-bazel.list
 RUN curl -Ls https://bazel.build/bazel-release.pub.gpg | apt-key add -
 
-RUN apt-get update -qq
-RUN apt-get install -qq \
-  git \
-  default-jdk \
-  bazel \
-  maven
+RUN apt-get update -qq \
+  && apt-get install -qq \
+    git \
+    default-jdk \
+    bazel \
+    maven
 
 RUN mkdir -p /var/build/snow
 WORKDIR /var/build/snowblossom

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
 RUN apt-get update
 RUN apt-get install --yes curl gpg git apt-utils default-jdk maven
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/snowblossom-bazel.list

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,15 +24,17 @@ RUN apt-get update -qq \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /var/build/snow
-WORKDIR /var/build/snowblossom
+RUN useradd -ms /bin/bash snowblossom
+RUN chown -R snowblossom:snowblossom /home/snowblossom
 
+USER snowblossom
+WORKDIR /home/snowblossom
 RUN git clone https://github.com/snowblossomcoin/rosesnow.git -b v0.1 rosesnow.git
 
-WORKDIR /var/build/snowblossom/rosesnow.git
+WORKDIR /home/snowblossom/rosesnow
 RUN bazel build :RoseSnow_deploy.jar
 
-WORKDIR /var/build/snowblossom/rosesnow.git/maven
+WORKDIR /home/snowblossom/rosesnow/maven
 
 EXPOSE 8080/tcp
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,13 @@ FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
-RUN apt-get update
-RUN apt-get install --yes curl gpg git apt-utils default-jdk maven
+RUN apt-get update -qq
+RUN apt-get install -qq curl gpg git apt-utils default-jdk maven
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/snowblossom-bazel.list
 RUN curl -Ls https://bazel.build/bazel-release.pub.gpg | apt-key add -
 
-RUN apt-get update
-RUN apt-get install --yes bazel
+RUN apt-get update -qq
+RUN apt-get install -qq bazel
 
 RUN mkdir -p /var/build/snow
 WORKDIR /var/build/snowblossom

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -Ls https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update -qq \
   && apt-get install -qq --no-install-recommends --no-install-suggests \
     git \
-    default-jdk \
+    default-jdk-headless \
     bazel \
     maven
 


### PR DESCRIPTION
* Reduce transient layer count
  * This helps with how demanding the local caching is on the storage of developer machines
* Improve use of apt-get
  * Quiet output
  * Clean all transient metadata up
* Use an unprivileged user for the build
*  General cleanups
* Move to a staged build and use Jetty 9 from the Ubuntu repositories

Known issue: the maven output `.war` does not work. I'll rebase and undraft this PR once a fix for that lands on the `main` branch.