### PR TITLE
Add jersey-media-json-jackson 2.32 to the Maven POM as a runtime dep

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -105,8 +105,14 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-inflector</artifactId>
             <version>${swagger-inflector-version}</version>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <version>2.32</version>
+            <scope>runtime</scope>
+          </dependency>
+          <dependency>
             <groupId>rosesnow</groupId>
             <artifactId>sample</artifactId>
             <version>1.0</version>


### PR DESCRIPTION
Turns out `io.swagger` was not able to render JSONs as there was no rendering provider bundled in.

Adding jersey-media-json-jackson 2.32 as a runtime dependency to the Maven POM fixes the .war and the container from #1 is able to serve the content now.